### PR TITLE
Corrected redirect json extension for apple-app-site-association

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,13 +5,13 @@
 
 [[redirects]]
   from = "/apple-app-site-association"
-  to = "/_well-known/apple-app-site-association.json"
+  to = "/_well-known/apple-app-site-association"
   status = 200
   force = true
 
 [[redirects]]
   from = "/.well-known/apple-app-site-association"
-  to = "/_well-known/apple-app-site-association.json"
+  to = "/_well-known/apple-app-site-association"
   status = 200
   force = true
 


### PR DESCRIPTION
- **Fixed typo in name**
